### PR TITLE
fix routing & header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,5 +67,5 @@ gem 'bootstrap-sass', '~> 3.3.6'
 gem 'jquery-rails'
 gem 'kaminari','~> 1.1.1'
 gem 'ransack'
-gem 'paranoia'
+gem "paranoia", "~> 2.0"
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ DEPENDENCIES
   jquery-rails
   kaminari (~> 1.1.1)
   listen (>= 3.0.5, < 3.2)
-  paranoia
+  paranoia (~> 2.0)
   puma (~> 3.11)
   rails (~> 5.2.3)
   ransack

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,11 @@
 class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
-    users_top_path # ログイン後に遷移するpathを設定
+    top_users_path # ログイン後に遷移するpathを設定
   end
 
   def after_sign_out_path_for(resource)
-    homes_top_path # ログアウト後に遷移するpathを設定
+    top_path # ログアウト後に遷移するpathを設定
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,7 @@ class UsersController < ApplicationController
   end
 
   def delete
+    @user = current_user
   end
 
   def index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :carts
 
+  acts_as_paranoid
 end

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -1,11 +1,3 @@
-<!DOCTYPE html>
-<html>
-<head>
-	<meta chaset="UTF-8" />
-	<link rel="stylesheet" href="style.css">
-	<title> NEWSED</title>
-</head>
-<body>
 	<div class="header"></div>
 
 	<div class="main-visual">
@@ -13,6 +5,3 @@
     </div>
     <div class="main"></div>
     <div class="footer"></div>
-</body>
-</html>
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,13 +16,14 @@
                 <h1>NEWSED</h1>
             <% if user_signed_in? %>
                 <li class="nav-list-item"><%= link_to " 新品一覧", items_path %></li>
+
                 <li class="nav-list-item"><%= link_to " 中古一覧", index_used_items_path %></li>
                 <li class="nav-list-item"><%= link_to " マイページ", top_users_path %></li>
                 <li class="nav-list-item"><%= link_to " ログアウト", destroy_user_session_path, method: :delete %></li>
-
+                  <%= button_to "ログアウト", destroy_user_session_path, method: :delete %>
                 <% else %>
                 <li class="nav-list-item"><%= link_to " 新品一覧", items_path %></li>
-                <li class="nav-list-item"><%= link_to " 中古一覧", index_used_item %></li>
+                <li class="nav-list-item"><%= link_to " 中古一覧", index_used_items_path %></li>
                 <li class="nav-list-item"><%= link_to " 会員登録", new_user_registration_path %></li>
                 <li class="nav-list-item"><%= link_to " ログイン", new_user_session_path %></li>
                 <% end %>

--- a/app/views/users/delete.html.erb
+++ b/app/views/users/delete.html.erb
@@ -2,6 +2,7 @@
 <p>登録したメールアドレスを入力して下さい。</p>
 
 <%= form_for(@user) do |f| %>
+
   <div class="field">
     <%= f.label :メールアドレス %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/users/top.html.erb
+++ b/app/views/users/top.html.erb
@@ -6,5 +6,5 @@
 　　<div class="box2">お気に入り一覧</div>
 　　<div class="box3">ユーザー編集</div>
 　　<div class="box4">
-	 <%= link_to "  退会", users_delete_path %>
+     <%= link_to "退会", delete_user_path(current_user.id) %>
    </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-
+  devise_for :users
   resources :items do
     collection do
       get :index_used
@@ -27,10 +27,9 @@ end
 
 
   resources :homes, only:[:index]
-  get '/' => 'homes#top'
+  get '/' => 'homes#top',as: "top"
 
   resources :artists, only:[:index, :create, :new, :destroy]
-  devise_for :users
   resources :genre, only:[:index, :create]
   resources :lable, only:[:index, :create]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20190418060730_remove_deleted_at_from_users.rb
+++ b/db/migrate/20190418060730_remove_deleted_at_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveDeletedAtFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :deleted_at, :string
+  end
+end

--- a/db/migrate/20190418061603_add_deleted_at_to_users.rb
+++ b/db/migrate/20190418061603_add_deleted_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :deleted_at, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_17_060839) do
+ActiveRecord::Schema.define(version: 2019_04_18_061603) do
 
   create_table "artists", force: :cascade do |t|
     t.text "artist_name"
@@ -131,8 +131,8 @@ ActiveRecord::Schema.define(version: 2019_04_17_060839) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "address"
-    t.string "deleted_at"
     t.boolean "admin", default: false
+    t.boolean "deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
ヘッダーからログアウトと中古一覧へ遷移できない問題を修正しました。
主な理由はconfig routes.rbのdevise_for :usersの位置が上部になく読み込みができないということでした。
ヘッダーの中古一覧のパスも修正しました。

これで退会ページへの遷移以外は全てできるようになりました。